### PR TITLE
[WIP] Add support for environment variables

### DIFF
--- a/management-api.md
+++ b/management-api.md
@@ -29,6 +29,9 @@ Example Response from your management API:
       "endpoint": "https://my-endpoint.example.com",
       "config": {
         "setting": "value"
+      },
+      "env": {
+        "ENV_VARIABLE": "value"
       }
     }
 


### PR DESCRIPTION
This would allow the management API to return an `env` property with a map of environment variables that will get merged into to the build and function environment variables, when provisioning or updating instances.

Use cases for this could be a provisioning API creating a new datastore and returning the DB URI that a Lambda would connect to, or a headless CMS returning adding an endpoint and API key to the build environment, etc...